### PR TITLE
Python 3.6 import urlparse trouble :)

### DIFF
--- a/xextract/parsers.py
+++ b/xextract/parsers.py
@@ -1,5 +1,11 @@
 from datetime import datetime
-import urlparse
+
+try:
+    # Python < 3
+    import urlparse as urlsparser
+except:
+    # Python >= 3
+    import urllib.parse as urlsparser
 
 from cssselect import GenericTranslator
 from lxml import etree
@@ -237,7 +243,7 @@ class Url(String):
     def _process_values(self, values, context):
         url = context.get('url')
         if url:
-            return [urlparse.urljoin(url, v.strip()) for v in values]
+            return [urlsparser.urljoin(url, v.strip()) for v in values]
         else:
             return [v.strip() for v in values]
 


### PR DESCRIPTION
In python 3.6 (I suppose) `urlparse` module is completely deprecated and `urllib.parse` should be used instead. That's a hotfix for the bug :)

Please push a new version to PYPI!